### PR TITLE
CombinationService

### DIFF
--- a/Nvents.Tests/CombinationServiceNetworkTests.cs
+++ b/Nvents.Tests/CombinationServiceNetworkTests.cs
@@ -15,14 +15,14 @@ namespace Nvents.Tests
         {
             int count = 0;
             service.DuplicateSuppression = DuplicateSuppressionOption.All;
-            Events.Subscribe<FooEvent>(e =>
+            service.Subscribe<FooEvent>(e =>
             {
                 if (e != null)
                     count++;
             });
 
             Test.WaitFor(() => count == 2, TimeSpan.FromSeconds(2), () =>
-                Events.Publish(new FooEvent()));
+                service.Publish(new FooEvent()));
 
             Assert.True(count == 1, String.Format("UniqueEvent was raised {0} times, instead of once", count));
         }
@@ -33,12 +33,12 @@ namespace Nvents.Tests
             int count = 0;
             int expectedCount = service.Services.Count;
             service.DuplicateSuppression = DuplicateSuppressionOption.UseEquals;
-            Events.Subscribe<FooEvent>(e => count++);
+            service.Subscribe<FooEvent>(e => count++);
 
-            Test.WaitFor(() => count == expectedCount, TimeSpan.FromSeconds(1), () =>
-                Events.Publish(new FooEvent()));
+            Test.WaitFor(() => count == expectedCount, TimeSpan.FromSeconds(5), () =>
+                service.Publish(new FooEvent()));
 
-            Assert.True(count == expectedCount, String.Format("FooEvent was not raised {0} times", expectedCount));
+            Assert.True(count >= expectedCount, String.Format("FooEvent was raised {0} times, expected {1}",count, expectedCount));
         }
 
         public CombinationServiceNetworkTests()
@@ -46,7 +46,6 @@ namespace Nvents.Tests
             service = new CombinationService(
                 new NetworkService(), new NetworkService());
             service.Start();
-            Events.Service = service;
         }
 	}
 }

--- a/Nvents.Tests/CombinationServiceNetworkTests.cs
+++ b/Nvents.Tests/CombinationServiceNetworkTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Data.Odbc;
+using System.Threading.Tasks;
+using Nvents.Services;
+using Xunit;
+
+namespace Nvents.Tests
+{
+	public class CombinationServiceNetworkTests
+	{
+	    private readonly CombinationService service;
+
+        [Fact]
+        public void CanFilterDuplicateEventWhenSuppressAll()
+        {
+            int count = 0;
+            service.DuplicateSuppression = DuplicateSuppressionOption.All;
+            Events.Subscribe<FooEvent>(e =>
+            {
+                if (e != null)
+                    count++;
+            });
+
+            Test.WaitFor(() => count == 2, TimeSpan.FromSeconds(2), () =>
+                Events.Publish(new FooEvent()));
+
+            Assert.True(count == 1, String.Format("UniqueEvent was raised {0} times, instead of once", count));
+        }
+
+        [Fact]
+        public void DoesNotFilterDuplicateEventWhenUseEqualsOnly()
+        {
+            int count = 0;
+            int expectedCount = service.Services.Count;
+            service.DuplicateSuppression = DuplicateSuppressionOption.UseEquals;
+            Events.Subscribe<FooEvent>(e => count++);
+
+            Test.WaitFor(() => count == expectedCount, TimeSpan.FromSeconds(1), () =>
+                Events.Publish(new FooEvent()));
+
+            Assert.True(count == expectedCount, String.Format("FooEvent was not raised {0} times", expectedCount));
+        }
+
+        public CombinationServiceNetworkTests()
+        {
+            service = new CombinationService(
+                new NetworkService(), new NetworkService());
+            service.Start();
+            Events.Service = service;
+        }
+	}
+}

--- a/Nvents.Tests/CombinationServiceTests.cs
+++ b/Nvents.Tests/CombinationServiceTests.cs
@@ -23,10 +23,10 @@ namespace Nvents.Tests
 		    int count = 0;
 		    int expectedCount = service.Services.Count;
             service.DuplicateSuppression = DuplicateSuppressionOption.None;
-			Events.Subscribe<FooEvent>(e => count++);
+			service.Subscribe<FooEvent>(e => count++);
 
             Test.WaitFor(() => count == expectedCount, TimeSpan.FromSeconds(1), () =>
-				Events.Publish(new FooEvent()));
+				service.Publish(new FooEvent()));
 
             Assert.True(count == expectedCount, String.Format("FooEvent was not raised {0} times", expectedCount));
 		}
@@ -36,10 +36,10 @@ namespace Nvents.Tests
         {
             int count = 0;
             service.DuplicateSuppression = DuplicateSuppressionOption.UseEquals;
-            Events.Subscribe<UniqueEvent>(e => count++);
+            service.Subscribe<UniqueEvent>(e => count++);
 
             Test.WaitFor(() => count == 2, TimeSpan.FromSeconds(1), () =>
-                Events.Publish(new UniqueEvent { ID = Guid.NewGuid()}));
+                service.Publish(new UniqueEvent { ID = Guid.NewGuid()}));
 
             Assert.True(count == 1, "UniqueEvent was raised more than once");
         }
@@ -49,14 +49,14 @@ namespace Nvents.Tests
         {
             int count = 0;
             service.DuplicateSuppression = DuplicateSuppressionOption.All;
-            Events.Subscribe<FooEvent>(e =>
+            service.Subscribe<FooEvent>(e =>
             {
                 if (e != null)
                     count++;
             });
 
             Test.WaitFor(() => count == 2, TimeSpan.FromSeconds(1), () =>
-                Events.Publish(new FooEvent()));
+                service.Publish(new FooEvent()));
 
             Assert.True(count == 1, "UniqueEvent was raised more than once");
         }
@@ -66,15 +66,15 @@ namespace Nvents.Tests
         {
             int count = 0;
             service.DuplicateSuppression = DuplicateSuppressionOption.All;
-            Events.Subscribe<UniqueEvent>(_=>{});
-            Events.Subscribe<FooEvent>(e =>
+            service.Subscribe<UniqueEvent>(_=>{});
+            service.Subscribe<FooEvent>(e =>
             {
                 if (e != null)
                     count++;
             });
 
             Test.WaitFor(() => count == 2, TimeSpan.FromSeconds(1), () =>
-                Events.Publish(new FooEvent()));
+                service.Publish(new FooEvent()));
 
             Assert.True(count == 1, "UniqueEvent was raised more than once");
         }
@@ -85,11 +85,12 @@ namespace Nvents.Tests
             int count = 0;
             service.UniqueCheckTimeLimit = TimeSpan.FromMilliseconds(10);
             service.DuplicateSuppression = DuplicateSuppressionOption.UseEquals;
-            Events.Subscribe<UniqueEvent>(e => count++);
+            
+            service.Subscribe<UniqueEvent>(e => count++);
 
             UniqueEvent nvent = new UniqueEvent { ID = Guid.NewGuid() };
-            Test.WaitFor(() => false, TimeSpan.FromSeconds(.1), () => Events.Publish(nvent));
-            Test.WaitFor(() => count==2, TimeSpan.FromSeconds(1), () => Events.Publish(nvent));
+            Test.WaitFor(() => false, TimeSpan.FromSeconds(.1), () => service.Publish(nvent));
+            Test.WaitFor(() => count==2, TimeSpan.FromSeconds(1), () => service.Publish(nvent));
 
             service.UniqueCheckTimeLimit = TimeSpan.FromMinutes(1);
             Assert.True(count == 2, String.Format("UniqueEvent was not raised second time after cache expiration"));
@@ -100,7 +101,6 @@ namespace Nvents.Tests
             service = new CombinationService(
                 new DummyService(), new DummyService());
             service.Start();
-            Events.Service = service;
         }
 	}
 }

--- a/Nvents.Tests/CombinationServiceTests.cs
+++ b/Nvents.Tests/CombinationServiceTests.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Data.Odbc;
+using System.Threading.Tasks;
+using Nvents.Services;
+using Xunit;
+
+namespace Nvents.Tests
+{
+	public class CombinationServiceTests
+	{
+	    private readonly CombinationService service;
+
+        [Fact]
+        public void AllServicesStarted()
+        {
+            foreach (IService srv in service.Services)
+                Assert.True(srv.IsStarted, "All Services weren't started");
+        }
+
+		[Fact]
+		public void CanPublishCombinationEvent()
+		{
+		    int count = 0;
+		    int expectedCount = service.Services.Count;
+            service.DuplicateSuppression = DuplicateSuppressionOption.None;
+			Events.Subscribe<FooEvent>(e => count++);
+
+            Test.WaitFor(() => count == expectedCount, TimeSpan.FromSeconds(1), () =>
+				Events.Publish(new FooEvent()));
+
+            Assert.True(count == expectedCount, String.Format("FooEvent was not raised {0} times", expectedCount));
+		}
+
+        [Fact]
+        public void CanFilterDuplicateEventWhenUnqiueOnly()
+        {
+            int count = 0;
+            service.DuplicateSuppression = DuplicateSuppressionOption.UniqueOnly;
+            Events.Subscribe<UniqueEvent>(e => count++);
+
+            Test.WaitFor(() => count == 2, TimeSpan.FromSeconds(1), () =>
+                Events.Publish(new UniqueEvent { ID = Guid.NewGuid()}));
+
+            Assert.True(count == 1, "UniqueEvent was raised more than once");
+        }
+        
+        [Fact]
+        public void DoesNotFilterDuplicateEventWhenUniqueOnly()
+        {
+            int count = 0;
+            int expectedCount = service.Services.Count;
+            service.DuplicateSuppression = DuplicateSuppressionOption.UniqueOnly;
+            Events.Subscribe<FooEvent>(e => count++);
+
+            Test.WaitFor(() => count == expectedCount, TimeSpan.FromSeconds(1), () =>
+                Events.Publish(new FooEvent()));
+
+            Assert.True(count == expectedCount, String.Format("FooEvent was not raised {0} times", expectedCount));
+        }
+
+        [Fact]
+        public void CanFilterDuplicateEventWhenSuppressAll()
+        {
+            int count = 0;
+            service.DuplicateSuppression = DuplicateSuppressionOption.All;
+            Events.Subscribe<FooEvent>(e =>
+            {
+                if (e != null)
+                    count++;
+            });
+
+            Test.WaitFor(() => count == 2, TimeSpan.FromSeconds(1), () =>
+                Events.Publish(new FooEvent()));
+
+            Assert.True(count == 1, "UniqueEvent was raised more than once");
+        }
+
+        [Fact]
+        public void ExpiresOldUniqueEvents()
+        {
+            int count = 0;
+            service.UniqueCheckTimeLimit = TimeSpan.FromMilliseconds(10);
+            service.DuplicateSuppression = DuplicateSuppressionOption.UniqueOnly;
+            Events.Subscribe<UniqueEvent>(e => count++);
+
+            UniqueEvent nvent = new UniqueEvent { ID = Guid.NewGuid() };
+            Test.WaitFor(() => false, TimeSpan.FromSeconds(.1), () => Events.Publish(nvent));
+            Test.WaitFor(() => count==2, TimeSpan.FromSeconds(1), () => Events.Publish(nvent));
+
+            service.UniqueCheckTimeLimit = TimeSpan.FromMinutes(1);
+            Assert.True(count == 2, String.Format("UniqueEvent was not raised second time after cache expiration"));
+        }
+
+        public CombinationServiceTests()
+        {
+            service = new CombinationService(
+                new DummyService(), new DummyService());
+            service.Start();
+            Events.Service = service;
+        }
+	}
+}

--- a/Nvents.Tests/Nvents.Tests.csproj
+++ b/Nvents.Tests/Nvents.Tests.csproj
@@ -75,7 +75,9 @@
     <Compile Include="EventSubscriptionTests.cs" />
     <Compile Include="FooBarHandler.cs" />
     <Compile Include="FooChildEvent.cs" />
+    <Compile Include="UniqueEvent.cs" />
     <Compile Include="FooEvent.cs" />
+    <Compile Include="CombinationServiceTests.cs" />
     <Compile Include="InMemoryServiceTests.cs" />
     <Compile Include="NamedPipesServiceTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -92,6 +94,9 @@
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />

--- a/Nvents.Tests/Nvents.Tests.csproj
+++ b/Nvents.Tests/Nvents.Tests.csproj
@@ -67,6 +67,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BarEvent.cs" />
+    <Compile Include="CombinationServiceNetworkTests.cs" />
     <Compile Include="DummyFooSubscriptions.cs" />
     <Compile Include="DummyHandler.cs" />
     <Compile Include="DummyService.cs" />

--- a/Nvents.Tests/UniqueEvent.cs
+++ b/Nvents.Tests/UniqueEvent.cs
@@ -1,0 +1,11 @@
+using System;
+using Nvents.Services;
+
+namespace Nvents.Tests
+{
+	public class UniqueEvent : IUniqueNvent
+	{
+		public string Baz { get; set; }
+        public Guid ID { get; set; }
+	}
+}

--- a/Nvents.Tests/UniqueEvent.cs
+++ b/Nvents.Tests/UniqueEvent.cs
@@ -1,11 +1,28 @@
 using System;
-using Nvents.Services;
 
 namespace Nvents.Tests
 {
-	public class UniqueEvent : IUniqueNvent
+	public class UniqueEvent
 	{
-		public string Baz { get; set; }
+	    public string Baz { get; set; }
         public Guid ID { get; set; }
+
+	    public override bool Equals(object obj)
+	    {
+	        if (ReferenceEquals(null, obj)) return false;
+	        if (ReferenceEquals(this, obj)) return true;
+	        if (obj.GetType() != this.GetType()) return false;
+	        return Equals((UniqueEvent) obj);
+	    }
+
+        protected bool Equals(UniqueEvent other)
+        {
+            return ID.Equals(other.ID);
+        }
+
+        public override int GetHashCode()
+        {
+            return ID.GetHashCode();
+        }
 	}
 }

--- a/Nvents/Nvents.csproj
+++ b/Nvents/Nvents.csproj
@@ -70,7 +70,6 @@
     <Compile Include="EventSubscription.cs" />
     <Compile Include="Services\CombinationService.cs" />
     <Compile Include="Services\InMemoryService.cs" />
-    <Compile Include="Services\IUniqueNvent.cs" />
     <Compile Include="Services\UniqueEventWrapper.cs" />
     <Compile Include="Services\Wcf\NamedPipesEventServiceClient.cs" />
     <Compile Include="Services\Wcf\NamedPipesEventServiceHost.cs" />

--- a/Nvents/Nvents.csproj
+++ b/Nvents/Nvents.csproj
@@ -68,7 +68,10 @@
     <Compile Include="PublishErrorEventArgs.cs" />
     <Compile Include="Services\EventRegistration.cs" />
     <Compile Include="EventSubscription.cs" />
+    <Compile Include="Services\CombinationService.cs" />
     <Compile Include="Services\InMemoryService.cs" />
+    <Compile Include="Services\IUniqueNvent.cs" />
+    <Compile Include="Services\UniqueEventWrapper.cs" />
     <Compile Include="Services\Wcf\NamedPipesEventServiceClient.cs" />
     <Compile Include="Services\Wcf\NamedPipesEventServiceHost.cs" />
     <Compile Include="Services\Wcf\TcpEventServiceClient.cs" />

--- a/Nvents/Services/CombinationService.cs
+++ b/Nvents/Services/CombinationService.cs
@@ -129,8 +129,20 @@ namespace Nvents.Services
 
     public enum DuplicateSuppressionOption
     {
+        /// <summary>
+        /// All will wrap all events and filter duplicates received for the same event
+        ///  based on a Guid in the wrapper
+        /// </summary>
         All,
+        /// <summary>
+        /// UseEquals will filter events that have already been received 
+        ///  if a matching object has been received based on the events Equals method
+        /// </summary>
         UseEquals,
+        /// <summary>
+        /// None will process all received events, regardless of whether or not they 
+        /// have previously been received and processed
+        /// </summary>
         None
     }
 }

--- a/Nvents/Services/CombinationService.cs
+++ b/Nvents/Services/CombinationService.cs
@@ -31,7 +31,7 @@ namespace Nvents.Services
         /// <summary>
         /// Setting to All causes all duplicate events to be filtered. 
         /// Setting to None will cause duplicate events to be handled again. 
-        /// Setting to UniqueOnly will suppress events that implement IUniqueNvent. 
+        /// Setting to UseEquals will suppress events that already been processed based on the Equals method. 
         /// </summary>
         public DuplicateSuppressionOption DuplicateSuppression { get; set; }
 

--- a/Nvents/Services/CombinationService.cs
+++ b/Nvents/Services/CombinationService.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Timers;
+
+namespace Nvents.Services
+{
+	/// <summary>
+	/// In memory service for publishing/subscribing to events in the same process
+	/// </summary>
+	public class CombinationService : ServiceBase
+	{
+        public List<IService> Services { get; private set; }
+
+	    readonly System.Timers.Timer timer = new System.Timers.Timer(60000) { AutoReset = false };
+	    private TimeSpan timeLimit = TimeSpan.FromMinutes(1);
+	    public TimeSpan UniqueCheckTimeLimit
+	    {
+	        get { return timeLimit; }
+	        set
+	        {
+	            timeLimit = value;
+	            timer.Interval = value.Milliseconds;
+	        }
+	    }
+
+        /// <summary>
+        /// Setting to All causes all duplicate events to be filtered. 
+        /// Setting to None will cause duplicate events to be handled again. 
+        /// Setting to UniqueOnly will suppress events that implement IUniqueNvent. 
+        /// </summary>
+        public DuplicateSuppressionOption DuplicateSuppression { get; set; }
+
+        readonly ConcurrentDictionary<Guid, Tuple<int, DateTime>> alreadyProcessedEvents = new ConcurrentDictionary<Guid, Tuple<int, DateTime>>();
+
+	    public CombinationService(params IService[] services)
+	    {
+	        DuplicateSuppression = DuplicateSuppressionOption.All;
+	        Services = services.ToList();
+	    }
+
+	    private void CleanupProcessedEvents(object sender, ElapsedEventArgs e)
+	    {
+	        try
+	        {
+                Tuple<int, DateTime> dummy;
+                DateTime earliestAllowedTime = DateTime.UtcNow.Subtract(UniqueCheckTimeLimit);
+                var expiredKeys = alreadyProcessedEvents
+                                    .Where(pair => pair.Value.Item2 < earliestAllowedTime)
+                                    .Select(pair => pair.Key).ToList();
+                foreach (var key in expiredKeys)
+                    alreadyProcessedEvents.TryRemove(key, out dummy);
+	        }
+	        catch
+	        {
+	        }
+
+            timer.Start();
+	    }
+
+	    protected override void OnStart()
+	    {
+	        foreach (IService service in Services)
+	        {
+	            service.Start();
+                service.Subscribe<object>(HandleEvent);
+	        }
+
+            timer.Elapsed += CleanupProcessedEvents;
+            timer.Start();
+	    }
+
+        protected override void OnStop()
+        {
+            timer.Stop();
+
+            foreach (IService service in Services)
+            {
+                service.Stop();
+                service.Unsubscribe<object>();
+            }
+        }
+
+	    private void HandleEvent(object nvent)
+	    {
+            foreach (var registration in registrations
+                .Where(x => ShouldEventBeHandled(x, nvent)))
+            {
+                // Unwrap if wrapped for DuplicateSuppression == All
+                //  so correct event is passed to handler
+                object nvent2 = UnwrapEvent(nvent);
+                ThreadPool.QueueUserWorkItem(s =>
+                    ((EventRegistration)s).Action(nvent2), registration);
+            }
+	    }
+
+	    private int lastEventNumber;
+	    protected override bool ShouldEventBeHandled(EventRegistration registration, object e)
+	    {
+            if (DuplicateSuppression != DuplicateSuppressionOption.None)
+	        {
+                // Make sure Unique event is only handled once
+                // Assign a number each time an event is processed, only process the event
+                // if the same number is in the dictionary (indicated it was just added this time around)
+	            IUniqueNvent unique = e as IUniqueNvent;
+	            if (unique != null)
+	            {
+                    int localNumber = Interlocked.Increment(ref lastEventNumber);
+	                var eventData = alreadyProcessedEvents.GetOrAdd(unique.ID, new Tuple<int, DateTime>(localNumber, DateTime.UtcNow));
+	                if (eventData.Item1 != localNumber)
+                        return false;
+	            }
+
+                // Unwrap if wrapped for DuplicateSuppression == All
+                //  so base.ShouldEventBeHandled checks the correct type
+                e = UnwrapEvent(e);
+	        }
+
+	        return base.ShouldEventBeHandled(registration, e);
+	    }
+
+	    private static object UnwrapEvent(object nvent)
+	    {
+	        UniqueEventWrapper wrapper = nvent as UniqueEventWrapper;
+	        if (wrapper != null)
+	            nvent = wrapper.Event;
+	        return nvent;
+	    }
+
+	    public override void Publish<TEvent>(TEvent e)
+		{
+            object nvent = DuplicateSuppression==DuplicateSuppressionOption.All 
+                            && !(e is IUniqueNvent)
+                            ? new UniqueEventWrapper(e)
+                            : (object)e;
+
+			foreach(IService service in Services)
+                service.Publish(nvent);
+		}
+	}
+
+    public enum DuplicateSuppressionOption
+    {
+        All,
+        UniqueOnly,
+        None
+    }
+}

--- a/Nvents/Services/HandlerUtility.cs
+++ b/Nvents/Services/HandlerUtility.cs
@@ -24,8 +24,8 @@ namespace Nvents.Services
 					.IsClass
 				select p.ParameterType;
 
-			if (eventTypes.Count() == 0)
-				throw new ArgumentException(string.Format("Handler {0} does not contain any methods named Handle which accepts only one parameter with type that derives from IEvent.", handler.GetType().Name));
+			if (!eventTypes.Any())
+				throw new ArgumentException(string.Format("Handler {0} does not contain any methods named Handle which accepts only one parameter that is a class (not a value type).", handler.GetType().Name));
 			return eventTypes.ToArray();
 		}
 	}

--- a/Nvents/Services/IUniqueNvent.cs
+++ b/Nvents/Services/IUniqueNvent.cs
@@ -1,9 +1,0 @@
-using System;
-
-namespace Nvents.Services
-{
-	public interface IUniqueNvent
-	{
-		Guid ID { get; }
-	}
-}

--- a/Nvents/Services/IUniqueNvent.cs
+++ b/Nvents/Services/IUniqueNvent.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Nvents.Services
+{
+	public interface IUniqueNvent
+	{
+		Guid ID { get; }
+	}
+}

--- a/Nvents/Services/ServiceBase.cs
+++ b/Nvents/Services/ServiceBase.cs
@@ -192,7 +192,7 @@ namespace Nvents.Services
 		/// <param name="registration">The internal event registration</param>
 		/// <param name="e">The event that was published</param>
 		/// <returns>True if the event should be handled</returns>
-		protected bool ShouldEventBeHandled(EventRegistration registration, object e)
+		protected virtual bool ShouldEventBeHandled(EventRegistration registration, object e)
 		{
 			var eventType = e.GetType();
 			var registrationEventType = registration.EventType;
@@ -201,13 +201,10 @@ namespace Nvents.Services
 				.GetInterfaces()
 				.Where(x => x.Name == typeof(IHandler<>).Name);
 
-			if (registrationInterfaces.Count() > 0)
+			if(registrationInterfaces
+				.Any(x => x.GetGenericArguments().FirstOrDefault() == eventType))
 			{
-				if(registrationInterfaces
-					.Any(x => x.GetGenericArguments().FirstOrDefault() == eventType))
-				{
-					registrationEventType = eventType;
-				}
+				registrationEventType = eventType;
 			}
 
 			return registrationEventType == eventType

--- a/Nvents/Services/UniqueEventWrapper.cs
+++ b/Nvents/Services/UniqueEventWrapper.cs
@@ -2,15 +2,52 @@
 
 namespace Nvents.Services
 {
-    internal class UniqueEventWrapper : IUniqueNvent
+    [Serializable]
+    internal class UniqueEventWrapper : IEquatable<UniqueEventWrapper>
     {
+
         public object Event { get; private set; }
         public Guid ID { get; private set; }
 
         public UniqueEventWrapper(object nvent)
         {
+            if (nvent==null)
+                throw new ArgumentNullException("nvent", "Event object must be supplied for UniqueEventWrapper");
+            
             Event = nvent;
             ID = Guid.NewGuid();
+        }
+
+        public bool Equals(UniqueEventWrapper other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            if (this.Event == null || other.Event == null) return false;
+            if (this.Event.GetType() != other.Event.GetType()) return false;
+            return ID.Equals(other.ID);
+        }
+
+        public override int GetHashCode()
+        {
+            return ID.GetHashCode();
+        }
+
+        public static bool operator ==(UniqueEventWrapper left, UniqueEventWrapper right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(UniqueEventWrapper left, UniqueEventWrapper right)
+        {
+            return !Equals(left, right);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((UniqueEventWrapper) obj);
         }
     }
 }

--- a/Nvents/Services/UniqueEventWrapper.cs
+++ b/Nvents/Services/UniqueEventWrapper.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Nvents.Services
+{
+    internal class UniqueEventWrapper : IUniqueNvent
+    {
+        public object Event { get; private set; }
+        public Guid ID { get; private set; }
+
+        public UniqueEventWrapper(object nvent)
+        {
+            Event = nvent;
+            ID = Guid.NewGuid();
+        }
+    }
+}


### PR DESCRIPTION
A service that allows for combining other services.  Options to handle suppression of duplicate event processing.  
This allows a setup where InMemoryService can be used for quick updates in the current process, while still sending the messages to other processes over the wcf interface using NetworkService.  
